### PR TITLE
Keep "privileged" variable a string

### DIFF
--- a/modules/ecs_container_definition/main.tf
+++ b/modules/ecs_container_definition/main.tf
@@ -29,7 +29,7 @@ locals {
     command                = "${var.command}"
     workingDirectory       = "${var.working_directory}"
     readonlyRootFilesystem = "${var.readonly_root_filesystem}"
-    privileged             = "${local.safe_search_replace_string}${var.privileged}"
+    privileged             = "${var.privileged}"
 
     hostname = "${var.hostname}"
 

--- a/modules/ecs_container_definition/main.tf
+++ b/modules/ecs_container_definition/main.tf
@@ -29,7 +29,7 @@ locals {
     command                = "${var.command}"
     workingDirectory       = "${var.working_directory}"
     readonlyRootFilesystem = "${var.readonly_root_filesystem}"
-    privileged             = "${var.privileged}"
+    privileged             = "${local.safe_search_replace_string}${var.privileged}"
 
     hostname = "${var.hostname}"
 

--- a/modules/ecs_container_definition/variables.tf
+++ b/modules/ecs_container_definition/variables.tf
@@ -49,6 +49,7 @@ variable "container_cpu" {
 variable "privileged" {
   description = "Bool. Run the container with elevated privilege."
   default     = "false"
+  type        = "string"
 }
 
 variable "essential" {

--- a/variables.tf
+++ b/variables.tf
@@ -204,7 +204,8 @@ variable "container_memory_reservation" {
 
 variable "privileged" {
   description = "Bool. Run the container with elevated privilege."
-  default     = false
+  default     = "false"
+  type        = "string"
 }
 
 # port defines the needed port of the container


### PR DESCRIPTION
The default false was converted to 0 by Terraform. This should fix it, after JSON conversion `"false"` will be converted to `false` anyway.